### PR TITLE
アップロードした画像の圧縮機能追加

### DIFF
--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -65,7 +65,16 @@ class MenusController < ApplicationController
 
   private
   def menu_params
-    params.require(:menu).permit(:name, :url, :memo, :image).merge(user_id: current_user.id)
+    image_size =  ImageProcessing::MiniMagick.source(params.require(:menu).permit(:image)[:image].tempfile).call.size
+  # 画像が500kB以上ならリサイズする
+    if image_size > 500000
+      resized_image = ImageProcessing::MiniMagick.source(params.require(:menu).permit(:image)[:image].tempfile).resize_to_fit(500,500).call
+      new_params = params
+      new_params.require(:menu).permit(:image)[:image].tempfile = resized_image
+      new_params.require(:menu).permit(:name, :url, :memo, :image).merge(user_id: current_user.id)
+    else
+      params.require(:menu).permit(:name, :url, :memo, :image).merge(user_id: current_user.id)
+    end
   end
 
   def move_to_index


### PR DESCRIPTION
## What
ユーザーが画像をアップロードをする際、その画像のファイルサイズが500kB以上だったらファイルサイズを圧縮するようにした。最新のiPhoneのカメラの最大容量が4MBであることを考慮し、ファイルサイズの大きさを試行錯誤した結果、500kB以下であれば、問題なく表示されることを確認した。

## Why
アプリ起動時や、ページ読み込み時に、画像の読み込みが遅く、全て表示されるまでに時間がかかり、ユーザーの満足度が下がると考えたから。