### PR TITLE
Bugfix/show back button issue

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,17 +1,24 @@
 class FavoritesController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_menu
   
   def create
     if user_signed_in?
       favorite = current_user.favorites.build(menu_id: params[:menu_id])
       favorite.save
-      redirect_to request.referer
+   
+      render 'create.js.erb'
+   
     end
   end
 
   def destroy
     favorite = Favorite.find_by(menu_id: params[:menu_id], user_id: current_user.id)
     favorite.destroy
-    redirect_to request.referer
+    render 'destroy.js.erb'
+  end
+
+  def set_menu
+    @menu = Menu.find(params[:menu_id])
   end
 end

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -67,7 +67,7 @@ class MenusController < ApplicationController
   def menu_params
     if params.require(:menu).permit(:image)[:image]
       image_size =  ImageProcessing::MiniMagick.source(params.require(:menu).permit(:image)[:image].tempfile).call.size
-    # 画像が500kB以上ならリサイズする
+      # 画像が500kB以上ならリサイズする
       if image_size > 500000
         resized_image = ImageProcessing::MiniMagick.source(params.require(:menu).permit(:image)[:image].tempfile).resize_to_fit(500,500).call
         new_params = params

--- a/app/views/favorites/_favorite.html.erb
+++ b/app/views/favorites/_favorite.html.erb
@@ -1,0 +1,9 @@
+<% if user_signed_in? && menu.favorited_by?(current_user) %>
+  <%=link_to menu_favorites_path(menu.id), method: :delete ,remote: true do %>
+    <i class="fa-solid fa-star unlike-btn"></i>
+  <% end %>
+<% else %>
+  <%=link_to menu_favorites_path(menu.id), method: :post,remote: true do %>
+    <i class="fa-solid fa-star like-btn"></i>
+  <% end %>
+<% end %>

--- a/app/views/favorites/create.js.erb
+++ b/app/views/favorites/create.js.erb
@@ -1,0 +1,2 @@
+document.getElementById('favorite-button<%= @menu.id %>').innerHTML = "<%= j(render partial: 'favorites/favorite', locals: {menu: @menu}) %>"
+

--- a/app/views/favorites/destroy.js.erb
+++ b/app/views/favorites/destroy.js.erb
@@ -1,0 +1,2 @@
+document.getElementById('favorite-button<%= @menu.id %>').innerHTML = "<%= j(render partial: 'favorites/favorite', locals: {menu: @menu}) %>"
+

--- a/app/views/menus/show.html.erb
+++ b/app/views/menus/show.html.erb
@@ -24,15 +24,9 @@
   <div class= "show-bar">
    
     <div class= "like-container">
-        <% if user_signed_in? && @menu.favorited_by?(current_user)%>
-          <%=link_to menu_favorite_path(@menu.id),  method: :delete  do%>
-          <i class="fa-solid fa-star unlike-btn"></i>
-          <% end %>
-        <% else %>
-          <%=link_to menu_favorites_path(@menu.id), method: :post do %>
-            <i class="fa-solid fa-star like-btn"></i>
-          <% end %>
-        <% end %>
+      <div id="favorite-button<%= @menu.id %>">
+        <%= render partial: "favorites/favorite", locals: {menu: @menu}%>
+      </div>
     </div>
     
     <div class="share-container">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
       get 'search'
       get 'following_menus'
     end
-    resources :favorites, only: [:create, :destroy]
+    resource :favorites, only: [:create, :destroy]
   end 
   resources :users, only: :show do
     member do


### PR DESCRIPTION
## What
詳細ページにて、お気に入り登録をする前後でページの読み込みが行われているため、戻るボタンを押したときに、遷移前のページではなく、詳細ページが再度開かれてしまう。遷移前のページに戻れるように、お気に入りボタンの非同期化処理を加えた。

## Why
戻るを押しているのに、動作どおりにページが動かないのは違和感があるから。

